### PR TITLE
Resolve pytest failure

### DIFF
--- a/src/c20_server/in_progress.py
+++ b/src/c20_server/in_progress.py
@@ -1,0 +1,3 @@
+"""
+Implementation of In-Progress class
+"""

--- a/src/c20_server/in_progress.py
+++ b/src/c20_server/in_progress.py
@@ -1,3 +1,20 @@
 """
 Implementation of In-Progress class
 """
+from c20_server import job_queue_errors
+
+
+class InProgress:
+
+    assigned_jobs_list = []
+
+    def assign(self, job, user):
+        self.assigned_jobs_list.append((job, user))
+
+    def unassign(self, job, user):
+        if (job, user) not in self.assigned_jobs_list:
+            raise job_queue_errors.UnassignInvalidDataException
+        self.assigned_jobs_list.remove((job, user))
+
+    def get_num_assigned_jobs(self):
+        return len(self.assigned_jobs_list)

--- a/src/c20_server/job_queue_errors.py
+++ b/src/c20_server/job_queue_errors.py
@@ -7,3 +7,9 @@ class NoJobsAvailableException(Exception):
     """
     Thrown exception for an empty unassigned_jobs_list.
     """
+
+
+class UnassignInvalidDataException(ValueError):
+    """
+    Thrown exception for assigning an invalid job.
+    """

--- a/src/c20_server/user.py
+++ b/src/c20_server/user.py
@@ -1,0 +1,5 @@
+
+class User:
+
+    def __init__(self, user_id):
+        self.user_id = user_id

--- a/tests/test_in_progress.py
+++ b/tests/test_in_progress.py
@@ -1,0 +1,4 @@
+
+"""
+Test class for In-Progress Class.
+"""

--- a/tests/test_in_progress.py
+++ b/tests/test_in_progress.py
@@ -2,3 +2,40 @@
 """
 Test class for In-Progress Class.
 """
+import pytest
+from c20_server import job_queue_errors
+from c20_server.job import Job
+from c20_server.user import User
+from c20_server.in_progress import InProgress
+
+
+JOB1 = Job(123)
+USER1 = User(1)
+
+
+def test_no_assigned_jobs():
+    assert InProgress().get_num_assigned_jobs() == 0
+
+
+def test_assign_one_job():
+    assert InProgress().get_num_assigned_jobs() == 0
+    InProgress().assign(JOB1, USER1)
+    assert InProgress().get_num_assigned_jobs() == 1
+
+
+def test_unassign_invalid_job():
+    invalid_job = Job(222)
+    with pytest.raises(job_queue_errors.UnassignInvalidDataException):
+        InProgress().unassign(invalid_job, USER1)
+
+
+def test_unassign_invalid_user():
+    invalid_user = User(66)
+    with pytest.raises(job_queue_errors.UnassignInvalidDataException):
+        InProgress().unassign(JOB1, invalid_user)
+
+
+def test_unassign_one_job():
+    assert InProgress().get_num_assigned_jobs() == 1
+    InProgress().unassign(JOB1, USER1)
+    assert InProgress().get_num_assigned_jobs() == 0

--- a/tests/test_job_manager.py
+++ b/tests/test_job_manager.py
@@ -35,3 +35,13 @@ def test_request_job():
 
 def test_one_unassigned_job_after_request():
     assert JobManager.num_unassigned() == 1
+
+
+def test_request_second_job():
+    user = 11
+    JobManager.request_job(user)
+    assert JobQueue().get_num_unassigned_jobs() == 0
+
+
+def test_no_unassigned_job_after_second_request():
+    assert JobManager.num_unassigned() == 0


### PR DESCRIPTION
by adding test_request_second_job to get back empty unassigned job list. Since the test_job_queue() and test_job_manager() tests use the same unassigned job list, the test_job_queue() tests start by assuming that the list is empty.